### PR TITLE
Update FAKE_FW_VERSION to 9.9

### DIFF
--- a/installer/include/defines.h
+++ b/installer/include/defines.h
@@ -9,7 +9,7 @@
 #define LOG_IP   "192.168.1.3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
 #define LOG_PORT 9023
 
-#define FAKE_FW_VERSION 0x07020000
+#define FAKE_FW_VERSION 0x09900000
 
 struct filedesc {
 	void *useless1[3];


### PR DESCRIPTION
Hi xXxTheDarkprogramerxXx,

Due to ps4 7.55 fw jailbreak availability, a lot of people using your HEN (2.1.4) faced an issue with installing and launching games which requires fw older than 7.02. They do a manual spoof to later FW versions after HEN activation.

I'd like to ask is it enough to increase FAKE_FW_VERSION to achive "FW Version Spoof to 9.9"? I've not yet tested these changes.